### PR TITLE
Missing URLs added to tutorial 3

### DIFF
--- a/tutorials/03.auto-train-models.ipynb
+++ b/tutorials/03.auto-train-models.ipynb
@@ -374,7 +374,7 @@
     "> * Review training results\n",
     "> * Register the best model\n",
     "\n",
-    "Learn more about [how to configure settings for automatic training]() or [how to use automatic training on a remote resource]()."
+    "Learn more about [how to configure settings for automatic training](https://docs.microsoft.com/en-us/azure/machine-learning/service/how-to-configure-auto-train) or [how to use automatic training on a remote resource](https://docs.microsoft.com/en-us/azure/machine-learning/service/how-to-auto-train-remote)."
    ]
   }
  ],


### PR DESCRIPTION
Added missing links to Azure automatic ml documentation on tutorial 03.auto-train-models.ipynb, Next steps chapter at the end of the document.

I assume these URIs are the ones that the links are supposed to lead into. If they are not correct, just reject this PR. 