### PR TITLE
Update 03.auto-train-models.ipynb

### DIFF
--- a/tutorials/03.auto-train-models.ipynb
+++ b/tutorials/03.auto-train-models.ipynb
@@ -187,7 +187,7 @@
         "|**max_time_sec**|12,000|Time limit in seconds for each iteration|\n",
         "|**iterations**|20|Number of iterations. In each iteration, the model trains with the data with a specific pipeline|\n",
         "|**n_cross_validations**|3|Number of cross validation splits|\n",
-        "|**exit_score**|0.9985|*double* value indicating the target for *primary_metric*. Once the target is surpassed the run terminates|\n",
+        "|**exit_score**|0.9995|*double* value indicating the target for *primary_metric*. Once the target is surpassed the run terminates|\n",
         "|**blacklist_algos**|['kNN','LinearSVM']|*Array* of *strings* indicating algorithms to ignore.\n"
       ]
     },
@@ -272,6 +272,13 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "You can find iteration=9 shows the best metric."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "### Retrieve all iterations\n",
         "\n",
         "View the experiment history and see individual metrics for each iteration run."
@@ -326,7 +333,7 @@
         "# register model in workspace\n",
         "description = 'Automated Machine Learning Model'\n",
         "tags = None\n",
-        "local_run.register_model(description=description, tags=tags)\n",
+        "local_run.register_model(description=description, tags=tags, iteration=9)\n",
         "local_run.model_id # Use this id to deploy the model as a web service in Azure"
       ]
     },


### PR DESCRIPTION
Basically current local_run.register_model() fails as it does not specify which iteration to register. 
To fix this, first, I've set the exit_score to 0.9995. This allows we see all 20 interations.
Then, I added description that iteration=9 is the best model, confirmed from Widget.
Lastly, I've added **iteration=9** as a parameter to register_model() call. This ensures successful registration of the model.