### PR TITLE
Fix tutorial 2

### DIFF
--- a/tutorials/02.deploy-models.ipynb
+++ b/tutorials/02.deploy-models.ipynb
@@ -480,7 +480,7 @@
         "test_samples = bytes(test_samples, encoding = 'utf8')\n",
         "\n",
         "# predict using the deployed model\n",
-        "result = service.run(input_data=test_samples)\n",
+        "result = json.loads(service.run(input_data=test_samples))\n",
         "\n",
         "# compare actual value vs. the predicted values:\n",
         "i = 0\n",


### PR DESCRIPTION
Hello!

The commit 114449d breaks the comparison between the true classes and the classes predicted by the deployed service at the end of tutorial 2.

The value returned by service.run is a JSON thus it must be deserialized. Otherwise, we compare the predicted classes to the characters of a JSON string.