### PR TITLE
Update train-on-remote-vm.ipynb

### DIFF
--- a/how-to-use-azureml/training/train-on-remote-vm/train-on-remote-vm.ipynb
+++ b/how-to-use-azureml/training/train-on-remote-vm/train-on-remote-vm.ipynb
@@ -243,7 +243,7 @@
     "                                                   ssh_port=22,\n",
     "                                                   private_key_file='./.ssh/id_rsa')\n",
     "attached_dsvm_compute = ComputeTarget.attach(workspace=ws,\n",
-    "                                             name='attached_vm',\n",
+    "                                             name='attached-vm',\n",
     "                                             attach_configuration=attach_config)\n",
     "attached_dsvm_compute.wait_for_completion(show_output=True)\n",
     "'''\n"


### PR DESCRIPTION
Compute name is invalid, it should start with a letter, be between 2 and 16 character, and only include letters (a-zA-Z), numbers (0-9) and \'-\'"