### PR TITLE
adding macOS specific yml. Install nomkl to workaround openmp issue

### DIFF
--- a/how-to-use-azureml/automated-machine-learning/automl_env_mac.yml
+++ b/how-to-use-azureml/automated-machine-learning/automl_env_mac.yml
@@ -1,0 +1,22 @@
+name: azure_automl
+dependencies:
+  # The python interpreter version.
+  # Currently Azure ML only supports 3.5.2 and later.
+- nomkl
+- python>=3.5.2,<3.6.8
+- nb_conda
+- matplotlib==2.1.0
+- numpy>=1.11.0,<=1.16.2
+- cython
+- urllib3<1.24
+- scipy>=1.0.0,<=1.1.0
+- scikit-learn>=0.19.0,<=0.20.3
+- pandas>=0.22.0,<0.23.0
+- py-xgboost<=0.80
+
+- pip:
+  # Required packages for AzureML execution, history, and data preparation.
+  - azureml-sdk[automl,explain]
+  - azureml-widgets
+  - pandas_ml
+  

--- a/how-to-use-azureml/automated-machine-learning/automl_setup_mac.sh
+++ b/how-to-use-azureml/automated-machine-learning/automl_setup_mac.sh
@@ -12,7 +12,7 @@ fi
 
 if [ "$AUTOML_ENV_FILE" == "" ]
 then
-  AUTOML_ENV_FILE="automl_env.yml"
+  AUTOML_ENV_FILE="automl_env_mac.yml"
 fi
 
 if [ ! -f $AUTOML_ENV_FILE ]; then


### PR DESCRIPTION
Certain mac installations create multiple openmp installations during training. This just changes the setup script to install nomkl, according to the workaround mentioned here: https://github.com/openai/spinningup/issues/16