### PR TITLE
Fix PredictionClient import.

### DIFF
--- a/how-to-use-azureml/deployment/accelerated-models/accelerated-models-object-detection.ipynb
+++ b/how-to-use-azureml/deployment/accelerated-models/accelerated-models-object-detection.ipynb
@@ -354,7 +354,7 @@
    "outputs": [],
    "source": [
     "# Using the grpc client in AzureML Accelerated Models SDK\n",
-    "from azureml.accel.client import PredictionClient\n",
+    "from azureml.accel import PredictionClient\n",
     "\n",
     "address = aks_service.scoring_uri\n",
     "ssl_enabled = address.startswith(\"https\")\n",


### PR DESCRIPTION
The PredcitionClient class is no longer available in: azureml.accel.client .
According to the official [docs](https://docs.microsoft.com/en-us/python/api/azureml-accel-models/azureml.accel.predictionclient?view=azure-ml-py) it is in : azureml.accel .