### PR TITLE
Fixed cpu-cluster creation

### DIFF
--- a/how-to-use-azureml/machine-learning-pipelines/intro-to-pipelines/aml-pipelines-how-to-use-estimatorstep.ipynb
+++ b/how-to-use-azureml/machine-learning-pipelines/intro-to-pipelines/aml-pipelines-how-to-use-estimatorstep.ipynb
@@ -107,7 +107,7 @@
         "    print('Found existing compute target')\n",
         "except ComputeTargetException:\n",
         "    print('Creating a new compute target...')\n",
-        "    compute_config = AmlCompute.provisioning_configuration(vm_size='STANDARD_NC6', max_nodes=4)\n",
+        "    compute_config = AmlCompute.provisioning_configuration(vm_size='Standard_DS3_v2', max_nodes=4)\n",
         "\n",
         "    # create the cluster\n",
         "    cpu_cluster = ComputeTarget.create(ws, cluster_name, compute_config)\n",


### PR DESCRIPTION
It's called "cpu-cluster" but in fact creates a cluster based on NC_6 VMs. This change fixes that and uses DS3_V2 VMs instead.