### PR TITLE
Update hardcoded variable, removed old client ref

### DIFF
--- a/how-to-use-azureml/deployment/accelerated-models/accelerated-models-object-detection.ipynb
+++ b/how-to-use-azureml/deployment/accelerated-models/accelerated-models-object-detection.ipynb
@@ -170,7 +170,7 @@
         "    model_graph.restore_weights(sess)\n",
         "    tf.saved_model.simple_save(sess, \n",
         "                               model_save_path, \n",
-        "                               inputs={'images': in_images}, \n",
+        "                               inputs={in_images.name: in_images}, \n",
         "                               outputs=output_map)"
       ]
     },
@@ -377,7 +377,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "You can adapt the client [code](https://github.com/Azure/aml-real-time-ai/blob/master/pythonlib/amlrealtimeai/client.py) to meet your needs. There is also an example C# [client](https://github.com/Azure/aml-real-time-ai/blob/master/sample-clients/csharp).\n",
+        "There is also an example C# [client](https://github.com/Azure/aml-real-time-ai/blob/master/sample-clients/csharp).\n",
         "\n",
         "The service provides an API that is compatible with TensorFlow Serving. There are instructions to download a sample client [here](https://www.tensorflow.org/serving/setup)."
       ]


### PR DESCRIPTION
- Removed mention of outdated Python SDK client code, kept the C# example since I couldn't find the API reference.
- Updated hardcoded `'images'` that was used as a tensor input name to `in_images.name`. Since the name is configurable early on, it shouldn't be hardcoded later on.