### PR TITLE
add dataprep dependency to notebook

### DIFF
--- a/how-to-use-azureml/explain-model/azure-integration/scoring-time/train-explain-model-on-amlcompute-and-deploy.ipynb
+++ b/how-to-use-azureml/explain-model/azure-integration/scoring-time/train-explain-model-on-amlcompute-and-deploy.ipynb
@@ -241,7 +241,7 @@
         "\n",
         "azureml_pip_packages = [\n",
         "    'azureml-defaults', 'azureml-contrib-explain-model', 'azureml-core', 'azureml-telemetry',\n",
-        "    'azureml-explain-model'\n",
+        "    'azureml-explain-model', 'azureml-dataprep'\n",
         "]\n",
         " \n",
         "\n",


### PR DESCRIPTION
add dataprep dependency to train-explain-model-on-amlcompute-and-deploy.ipynb notebook for azureml-explain-model package