### PR TITLE
from 'img-classification-part2-deploy.ipynb', import joblib is better in local

### DIFF
--- a/tutorials/img-classification-part2-deploy.ipynb
+++ b/tutorials/img-classification-part2-deploy.ipynb
@@ -190,7 +190,7 @@
       "outputs": [],
       "source": [
         "import pickle\n",
-        "from sklearn.externals import joblib\n",
+        "import joblib\n",
         "\n",
         "clf = joblib.load( os.path.join(os.getcwd(), 'sklearn_mnist_model.pkl'))\n",
         "y_hat = clf.predict(X_test)"


### PR DESCRIPTION
Running the code in local, there is a key error when using 'from sklearn.externals import joblib'

It is because the difference version of joblib.
As there is a newer version of joblib, I recommend using newer joblib by correcting 'from sklearn.externals import joblib' to 'import joblib'
Otherwise, there is possibility to get key error in local. THX