### PR TITLE
Stop Train/Test Name Overwrite

### DIFF
--- a/how-to-use-azureml/automated-machine-learning/regression/auto-ml-regression.ipynb
+++ b/how-to-use-azureml/automated-machine-learning/regression/auto-ml-regression.ipynb
@@ -358,16 +358,16 @@
       "source": [
         "# preview the first 3 rows of the dataset\n",
         "\n",
-        "test_data = test_data.to_pandas_dataframe()\n",
-        "y_test = test_data['ERP'].fillna(0)\n",
-        "test_data = test_data.drop('ERP', 1)\n",
-        "test_data = test_data.fillna(0)\n",
+        "test_data_df = test_data.to_pandas_dataframe()\n",
+        "y_test = test_data_df['ERP'].fillna(0)\n",
+        "test_data_df = test_data_df.drop('ERP', 1)\n",
+        "test_data_df = test_data_df.fillna(0)\n",
         "\n",
         "\n",
-        "train_data = train_data.to_pandas_dataframe()\n",
-        "y_train = train_data['ERP'].fillna(0)\n",
-        "train_data = train_data.drop('ERP', 1)\n",
-        "train_data = train_data.fillna(0)\n"
+        "train_data_df = train_data.to_pandas_dataframe()\n",
+        "y_train = train_data_df['ERP'].fillna(0)\n",
+        "train_data_df = train_data_df.drop('ERP', 1)\n",
+        "train_data_df = train_data_df.fillna(0)\n"
       ]
     },
     {
@@ -376,10 +376,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "y_pred_train = fitted_model.predict(train_data)\n",
+        "y_pred_train = fitted_model.predict(train_data_df)\n",
         "y_residual_train = y_train - y_pred_train\n",
         "\n",
-        "y_pred_test = fitted_model.predict(test_data)\n",
+        "y_pred_test = fitted_model.predict(test_data_df)\n",
         "y_residual_test = y_test - y_pred_test"
       ]
     },


### PR DESCRIPTION
This cells `test_data` overwrite changes the type from `TabularDataset` to `DataFrame` this breaks cells from re-executing and can make the examples hard to follow and retool.