### PR TITLE
AutoML README.md simplified

### DIFF
--- a/how-to-use-azureml/automated-machine-learning/README.md
+++ b/how-to-use-azureml/automated-machine-learning/README.md
@@ -1,10 +1,9 @@
 # Table of Contents
 1. [Automated ML Introduction](#introduction)
-1. [Setup using Azure Notebooks](#jupyter)
-1. [Setup using Azure Databricks](#databricks)
+1. [Setup using Azure ML 'Compute Instance'](#jupyter)
 1. [Setup using a Local Conda environment](#localconda)
+1. [Setup using Azure Databricks](#databricks)
 1. [Automated ML SDK Sample Notebooks](#samples)
-1. [Documentation](#documentation)
 1. [Running using python command](#pythoncommand)
 1. [Troubleshooting](#troubleshooting)
 
@@ -17,82 +16,35 @@ If you are new to Data Science, automated ML will help you get jumpstarted by si
 
 If you are an experienced data scientist, automated ML will help increase your productivity by intelligently performing the model and hyperparameter selection for your training and generates high quality models much quicker than manually specifying several combinations of the parameters and running training jobs. Automated ML provides visibility and access to all the training jobs and the performance characteristics of the models to help you further tune the pipeline if you desire.
 
-Below are the three execution environments supported by automated ML.
-
-
  <a name="jupyter"></a>
-## Setup using Notebook VMs - Jupyter based notebooks from a Azure VM
+## Setup using Azure ML 'compute Instance' (aka. Notebook VM) - Jupyter notebooks in an Azure VM
+
+The easiest way to try these Azure Automated ML notebooks is by running them in the ready to use Azure Compute Instance (aka. Notebook VM) integrated to your Azure ML Workspace.
+
+You can quickly provision and use an Azure Compute Instance by following these steps:
 
 1. Open the [ML Azure portal](https://ml.azure.com)
-1. Select Compute
-1. Select Notebook VMs
+1. Enter into any of your Azure ML Workspaces. If you don't have any AML Workspace created, create a Workspace as explained [here](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-manage-workspace).
+1. Select 'Compute'
+1. Select 'Compute Instances' (aka. 'Notebook VMs') if not already selected.
 1. Click New
-1. Type a name for the Vm and select a VM type
+1. Type a name for the new 'Compute Instance' and select a VM size
 1. Click Create
+1. Once the VM is created and up and running, select the 'JupyterLab' so you can enter into the command line and clone the Azure ML Samples repo from there with:
+
+    ```
+    git clone https://github.com/Azure/MachineLearningNotebooks.git
+    ```
+1. You can now open the notebooks either from Jupyter-Lab, Jupyter or the integrated 'Notebooks' in the Workspace UI.
 
 <a name="localconda"></a>
-## Setup using a Local Conda environment
+## Setup using a local Conda environment
 
-To run these notebook on your own notebook server, use these installation instructions.
-The instructions below will install everything you need and then start a Jupyter notebook.
+If you are getting started with Azure ML and Azure Automated ML we encourage you to use the 'Azure ML Compute Instance' (aka. Notebook VM) explained above because its simplicity to use.
 
-### 1. Install mini-conda from [here](https://conda.io/miniconda.html), choose 64-bit Python 3.7 or higher.
-- **Note**: if you already have conda installed, you can keep using it but it should be version 4.4.10 or later (as shown by: conda -V).  If you have a previous version installed, you can update it using the command: conda update conda.
-There's no need to install mini-conda specifically.
+However, if you still want to run these notebooks on your own Jupyter notebook server/machine, you can follow these instructions:
 
-### 2. Downloading the sample notebooks
-- Download the sample notebooks from [GitHub](https://github.com/Azure/MachineLearningNotebooks) as zip and extract the contents to a local directory.  The automated ML sample notebooks are in the "automated-machine-learning" folder.
-
-### 3. Setup a new conda environment
-The **automl_setup** script creates a new conda environment, installs the necessary packages, configures the widget and starts a jupyter notebook. It takes the conda environment name as an optional parameter.  The default conda environment name is azure_automl.  The exact command depends on the operating system.  See the specific sections below for Windows, Mac and Linux.  It can take about 10 minutes to execute.
-
-Packages installed by the **automl_setup** script:
-    <ul><li>python</li><li>nb_conda</li><li>matplotlib</li><li>numpy</li><li>cython</li><li>urllib3</li><li>scipy</li><li>scikit-learn</li><li>pandas</li><li>tensorflow</li><li>py-xgboost</li><li>azureml-sdk</li><li>azureml-widgets</li><li>pandas-ml</li></ul>
-
-For more details refer to the [automl_env.yml](./automl_env.yml)
-## Windows
-Start an **Anaconda Prompt** window, cd to the **how-to-use-azureml/automated-machine-learning** folder where the sample notebooks were extracted and then run:
-```
-automl_setup
-```
-## Mac
-Install "Command line developer tools" if it is not already installed (you can use the command: `xcode-select --install`).
-
-Start a Terminal windows, cd to the **how-to-use-azureml/automated-machine-learning** folder where the sample notebooks were extracted and then run:
-
-```
-bash automl_setup_mac.sh
-```
-
-## Linux
-cd to the **how-to-use-azureml/automated-machine-learning** folder where the sample notebooks were extracted and then run:
-
-```
-bash automl_setup_linux.sh
-```
-
-### 4. Running configuration.ipynb
-- Before running any samples you next need to run the configuration notebook. Click on [configuration](../../configuration.ipynb) notebook
-- Execute the cells in the notebook to Register Machine Learning Services Resource Provider and create a workspace. (*instructions in notebook*)
-
-### 5. Running Samples
-- Please make sure you use the Python [conda env:azure_automl] kernel when trying the sample Notebooks.
-- Follow the instructions in the individual notebooks to explore various features in automated ML.
-
-### 6. Starting jupyter notebook manually
-To start your Jupyter notebook manually, use:
-
-```
-conda activate azure_automl
-jupyter notebook
-```
-
-or on Mac or Linux:
-
-```
-source activate azure_automl
-jupyter notebook
-```
+* [Setup AutoML using a local Conda environment](./SETUP-LOCAL-CONDA-ENVIRONMENT.md)
 
  <a name="databricks"></a>
 ## Setup using Azure Databricks

--- a/how-to-use-azureml/automated-machine-learning/README.md
+++ b/how-to-use-azureml/automated-machine-learning/README.md
@@ -17,7 +17,7 @@ If you are new to Data Science, automated ML will help you get jumpstarted by si
 If you are an experienced data scientist, automated ML will help increase your productivity by intelligently performing the model and hyperparameter selection for your training and generates high quality models much quicker than manually specifying several combinations of the parameters and running training jobs. Automated ML provides visibility and access to all the training jobs and the performance characteristics of the models to help you further tune the pipeline if you desire.
 
  <a name="jupyter"></a>
-## Setup using Azure ML 'compute Instance' (aka. Notebook VM) - Jupyter notebooks in an Azure VM
+## Setup using Azure ML 'Compute Instance' (aka. Notebook VM) - Jupyter notebooks in an Azure VM
 
 The easiest way to try these Azure Automated ML notebooks is by running them in the ready to use Azure Compute Instance (aka. Notebook VM) integrated to your Azure ML Workspace.
 

--- a/how-to-use-azureml/automated-machine-learning/SETUP-LOCAL-CONDA-ENVIRONMENT.md
+++ b/how-to-use-azureml/automated-machine-learning/SETUP-LOCAL-CONDA-ENVIRONMENT.md
@@ -1,0 +1,63 @@
+<a name="localconda"></a>
+## Setup Azure Automated ML using a Local Conda environment
+
+To run these notebook on your own notebook server, use these installation instructions.
+The instructions below will install everything you need and then start a Jupyter notebook.
+
+### 1. Install mini-conda from [here](https://conda.io/miniconda.html), choose 64-bit Python 3.7 or higher.
+- **Note**: if you already have conda installed, you can keep using it but it should be version 4.4.10 or later (as shown by: conda -V).  If you have a previous version installed, you can update it using the command: conda update conda.
+There's no need to install mini-conda specifically.
+
+### 2. Downloading the sample notebooks
+- Download the sample notebooks from [GitHub](https://github.com/Azure/MachineLearningNotebooks) as zip and extract the contents to a local directory.  The automated ML sample notebooks are in the "automated-machine-learning" folder.
+
+### 3. Setup a new conda environment
+The **automl_setup** script creates a new conda environment, installs the necessary packages, configures the widget and starts a jupyter notebook. It takes the conda environment name as an optional parameter.  The default conda environment name is azure_automl.  The exact command depends on the operating system.  See the specific sections below for Windows, Mac and Linux.  It can take about 10 minutes to execute.
+
+Packages installed by the **automl_setup** script:
+    <ul><li>python</li><li>nb_conda</li><li>matplotlib</li><li>numpy</li><li>cython</li><li>urllib3</li><li>scipy</li><li>scikit-learn</li><li>pandas</li><li>tensorflow</li><li>py-xgboost</li><li>azureml-sdk</li><li>azureml-widgets</li><li>pandas-ml</li></ul>
+
+For more details refer to the [automl_env.yml](./automl_env.yml)
+## Windows
+Start an **Anaconda Prompt** window, cd to the **how-to-use-azureml/automated-machine-learning** folder where the sample notebooks were extracted and then run:
+```
+automl_setup
+```
+## Mac
+Install "Command line developer tools" if it is not already installed (you can use the command: `xcode-select --install`).
+
+Start a Terminal windows, cd to the **how-to-use-azureml/automated-machine-learning** folder where the sample notebooks were extracted and then run:
+
+```
+bash automl_setup_mac.sh
+```
+
+## Linux
+cd to the **how-to-use-azureml/automated-machine-learning** folder where the sample notebooks were extracted and then run:
+
+```
+bash automl_setup_linux.sh
+```
+
+### 4. Running configuration.ipynb
+- Before running any samples you next need to run the configuration notebook. Click on [configuration](../../configuration.ipynb) notebook
+- Execute the cells in the notebook to Register Machine Learning Services Resource Provider and create a workspace. (*instructions in notebook*)
+
+### 5. Running Samples
+- Please make sure you use the Python [conda env:azure_automl] kernel when trying the sample Notebooks.
+- Follow the instructions in the individual notebooks to explore various features in automated ML.
+
+### 6. Starting jupyter notebook manually
+To start your Jupyter notebook manually, use:
+
+```
+conda activate azure_automl
+jupyter notebook
+```
+
+or on Mac or Linux:
+
+```
+source activate azure_automl
+jupyter notebook
+```


### PR DESCRIPTION
AutoML README.md simplified.
AML 'Compute Instance' should be the by default way to go.
Local Conda installation is now in a segregated page so it doesn't make the home README.md so complex.
