### PR TITLE
Update auto-ml-forecasting-bike-share.ipynb

### DIFF
--- a/how-to-use-azureml/automated-machine-learning/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
+++ b/how-to-use-azureml/automated-machine-learning/forecasting-bike-share/auto-ml-forecasting-bike-share.ipynb
@@ -450,8 +450,8 @@
         "\n",
         "script_folder = os.path.join(os.getcwd(), 'forecast')\n",
         "os.makedirs(script_folder, exist_ok=True)\n",
-        "shutil.copy2('forecasting_script.py', script_folder)\n",
-        "shutil.copy2('forecasting_helper.py', script_folder)"
+        "shutil.copy('forecasting_script.py', script_folder)\n",
+        "shutil.copy('forecasting_helper.py', script_folder)"
       ]
     },
     {


### PR DESCRIPTION
auto-ml-forecasting-bike-share.ipynb crashes in cell using shutil.copy2() under some versions of Python in the local environment.
Change to shutil.copy() so it works in most Python environments.