### PR TITLE
Include additional details on user authentication

### DIFF
--- a/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb
+++ b/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb
@@ -59,7 +59,7 @@
         "\n",
         "If the following code asks for additional authentication, simply paste the link in a browser and enter the authentication token. In addition, if you have more than one tenant linked to your user, you will need to add the following lines:\n",
         "from azureml.core.authentication import InteractiveLoginAuthentication\n",
-        "interactive_auth = InteractiveLoginAuthentication(tenant_id="your-tenant-id")\n",
+        "interactive_auth = InteractiveLoginAuthentication(tenant_id="\your-tenant-id\")\n",
         "Additional details on authentication can be found here: https://aka.ms/aml-notebook-auth \n"
        ]
     },

--- a/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb
+++ b/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb
@@ -29,10 +29,12 @@
         "\n",
         "In this tutorial, you learn the following tasks:\n",
         "\n",
+        "\n",
         "> * Connect your workspace and create an experiment \n",
         "> * Load data and train a scikit-learn model\n",
         "> * View training results in the studio\n",
-        "> * Retrieve the best model"
+        "> * Retrieve the best model",
+        "\n"
       ]
     },
     {

--- a/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb
+++ b/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb
@@ -57,8 +57,11 @@
       "source": [
         "Import the `Workspace` class, and load your subscription information from the file `config.json` using the function `from_config().` This looks for the JSON file in the current directory by default, but you can also specify a path parameter to point to the file using `from_config(path=\"your/file/path\")`. If you are running this notebook in a cloud notebook server in your workspace, the file is automatically in the root directory.\n",
         "\n",
-        "If the following code asks for additional authentication, simply paste the link in a browser and enter the authentication token."
-      ]
+        "If the following code asks for additional authentication, simply paste the link in a browser and enter the authentication token. In addition, if you have more than one tenant linked to your user, you will need to add the following lines:\n",
+        "from azureml.core.authentication import InteractiveLoginAuthentication\n",
+        "interactive_auth = InteractiveLoginAuthentication(tenant_id="your-tenant-id")\n",
+        "Additional details on authentication can be found here: https://aka.ms/aml-notebook-auth \n"
+       ]
     },
     {
       "cell_type": "code",

--- a/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb
+++ b/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb
@@ -29,12 +29,10 @@
         "\n",
         "In this tutorial, you learn the following tasks:\n",
         "\n",
-        "\n",
         "> * Connect your workspace and create an experiment \n",
         "> * Load data and train a scikit-learn model\n",
         "> * View training results in the studio\n",
-        "> * Retrieve the best model",
-        "\n"
+        "> * Retrieve the best model"
       ]
     },
     {
@@ -60,9 +58,11 @@
         "Import the `Workspace` class, and load your subscription information from the file `config.json` using the function `from_config().` This looks for the JSON file in the current directory by default, but you can also specify a path parameter to point to the file using `from_config(path=\"your/file/path\")`. If you are running this notebook in a cloud notebook server in your workspace, the file is automatically in the root directory.\n",
         "\n",
         "If the following code asks for additional authentication, simply paste the link in a browser and enter the authentication token. In addition, if you have more than one tenant linked to your user, you will need to add the following lines:\n",
+        "```\n",
         "from azureml.core.authentication import InteractiveLoginAuthentication\n",
         "interactive_auth = InteractiveLoginAuthentication(tenant_id=\"your-tenant-id\")\n",
-        "Additional details on authentication can be found here: https://aka.ms/aml-notebook-auth \n"
+        "Additional details on authentication can be found here: https://aka.ms/aml-notebook-auth \n",
+        "```\n"
        ]
     },
     {

--- a/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb
+++ b/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb
@@ -59,7 +59,7 @@
         "\n",
         "If the following code asks for additional authentication, simply paste the link in a browser and enter the authentication token. In addition, if you have more than one tenant linked to your user, you will need to add the following lines:\n",
         "from azureml.core.authentication import InteractiveLoginAuthentication\n",
-        "interactive_auth = InteractiveLoginAuthentication(tenant_id="\your-tenant-id\")\n",
+        "interactive_auth = InteractiveLoginAuthentication(tenant_id=\"your-tenant-id\")\n",
         "Additional details on authentication can be found here: https://aka.ms/aml-notebook-auth \n"
        ]
     },


### PR DESCRIPTION
Additional details should be included for user authentication esp. for enterprise users who may have more than one single aad tenant linked to a user.