### PR TITLE
docs: bring docs in line with code

### DIFF
--- a/how-to-use-azureml/machine-learning-pipelines/intro-to-pipelines/aml-pipelines-showcasing-datapath-and-pipelineparameter.ipynb
+++ b/how-to-use-azureml/machine-learning-pipelines/intro-to-pipelines/aml-pipelines-showcasing-datapath-and-pipelineparameter.ipynb
@@ -87,7 +87,7 @@
       "source": [
         "## Create an Azure ML experiment\n",
         "\n",
-        "Let's create an experiment named \"automl-classification\" and a folder to hold the training scripts. The script runs will be recorded under the experiment in Azure."
+        "Let's create an experiment named \"showcasing-datapath\" and a folder to hold the training scripts. The script runs will be recorded under the experiment in Azure."
       ]
     },
     {


### PR DESCRIPTION
A non-existant name was being referred to, which only serves confusion.