### PR TITLE
Specific scikit-learn version for example script

### DIFF
--- a/how-to-use-azureml/deployment/deploy-to-cloud/model-register-and-deploy.ipynb
+++ b/how-to-use-azureml/deployment/deploy-to-cloud/model-register-and-deploy.ipynb
@@ -292,7 +292,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "When using a custom environment, you must also provide Python code for initializing and running your model. An example script is included with this notebook."
+        "When using a custom environment, you must also provide Python code for initializing and running your model. An example script is included with this notebook, scikit-learn version should be 0.22+."
       ]
     },
     {


### PR DESCRIPTION
Should use scikit-learn higher version as we use "import joblib" in score.py.
For user who use scikit-learn lower than 0.22, will get CrashBackoff error during the model deployment, even without any logs.
That's a bad user experience.