### PR TITLE
Publish data_pipeline instead of training_pipeline

### DIFF
--- a/how-to-use-azureml/automated-machine-learning/continuous-retraining/auto-ml-continuous-retraining.ipynb
+++ b/how-to-use-azureml/automated-machine-learning/continuous-retraining/auto-ml-continuous-retraining.ipynb
@@ -529,7 +529,7 @@
       "source": [
         "pipeline_name = \"DataIngestion-Pipeline-NOAAWeather\"\n",
         "\n",
-        "published_pipeline = training_pipeline.publish(\n",
+        "published_pipeline = data_pipeline.publish(\n",
         "    name=pipeline_name, description=\"Pipeline that updates NOAAWeather Dataset\"\n",
         ")\n",
         "\n",


### PR DESCRIPTION
Publish data_pipeline instead of training_pipeline in the `Test Retraining` section